### PR TITLE
fix: :bug: 무한호출해결#3

### DIFF
--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -36,7 +36,7 @@ export function CalendarView() {
         console.error(error);
       }
     };
-    fetchData();
+    setTimeout(() => fetchData(), 5);
   }, [navYear, navMonth, addValue, editValue, deleteValue]);
 
   return (

--- a/src/components/calendar/WeeklyView.tsx
+++ b/src/components/calendar/WeeklyView.tsx
@@ -34,7 +34,7 @@ export function WeeklyView() {
         console.error(error);
       }
     };
-    fetchData();
+    setTimeout(() => fetchData(), 5);
   }, [navYear, navMonth, addValue, editValue, deleteValue]);
 
   useEffect(() => {

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -26,8 +26,6 @@ interface ISearchResultProps {
 
 function Search({ userId }: ISearchProps) {
   const addValue = useRecoilValue(openModalAtom);
-  const editValue = useRecoilValue(openEditModalAtom);
-  const deleteValue = useRecoilValue(openDeleteModalAtom);
   const [searchText, setSearchText] = useState("");
   const [searchResults, setSearchResults] = useState<ISearchResultProps[]>([]);
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
@@ -44,7 +42,6 @@ function Search({ userId }: ISearchProps) {
             userId: userId,
           });
           const data = result.data;
-          console.log(data);
           setSearchResults(data);
         } else {
           setSearchResults([]);
@@ -53,8 +50,8 @@ function Search({ userId }: ISearchProps) {
         console.log("Error occurred while searching:", error);
       }
     };
-    fetchData();
-  }, [searchText, userId, addValue, editValue, deleteValue]);
+    setTimeout(() => fetchData(), 5);
+  }, [searchText, userId, addValue, openEditModal, openDeleteModal]);
 
   const handleCloseDeleteModal = () => {
     setOpenDeleteModal(false);

--- a/src/components/today/Today.tsx
+++ b/src/components/today/Today.tsx
@@ -23,8 +23,6 @@ interface IExpense {
 export function Today() {
   const today = useRecoilValue(todayAtom);
   const addValue = useRecoilValue(openModalAtom);
-  const editValue = useRecoilValue(openEditModalAtom);
-  const deleteValue = useRecoilValue(openDeleteModalAtom);
   const [todayList, setTodayList] = useState([]);
   const [openEditModal, setOpenEditModal] = useRecoilState(openEditModalAtom);
   const [openDeleteModal, setOpenDeleteModal] =
@@ -48,8 +46,16 @@ export function Today() {
         console.error(error);
       }
     };
-    fetchData();
-  }, [editValue, deleteValue, addValue, today, nowDate, nowMonth, nowYear]);
+    setTimeout(() => fetchData(), 5);
+  }, [
+    openEditModal,
+    openDeleteModal,
+    addValue,
+    today,
+    nowDate,
+    nowMonth,
+    nowYear,
+  ]);
 
   const handleCloseDeleteModal = () => {
     setOpenDeleteModal(false);


### PR DESCRIPTION
# 수정사항
1. `fetch()`를 `setTimeOut`!
같은 api를 호출하고, modal이 close되는지 open되는지 감지하며 충분히 `useEffect`가 잘 동작하고 있음에도
캘린더에만 자동반영이 되고, 서치나 투데이에는 반영이 안 되는 이유가
**캘린더의 호출 속도가 서치나 투데이보다 느리기 때문이라는 것**을 `console.log`와 `Main.tsx`의 컴포넌트 순서 변경을 통해 알아냈습니다.
따라서 필요없는 `useRecoilValue`를 삭제하고 api 호출 속도를 조금 늦춰 자동반영이 되게끔 수정했습니다.
모달을 사용하는 모든 컴포넌트 내 함수호출 api에 setTimeout이 적용되었습니다.

> 최대한 setTimeout이 체감되지 않는 정도로 맞췄으나 조절이 더 필요하다면 말씀해주세요!

```
setTimeout(() => fetchData(), 5);
```
