### PR TITLE
리팩토링 및 자동 업데이트 오류 해결 PR

### DIFF
--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -36,7 +36,7 @@ export function CalendarView() {
         console.error(error);
       }
     };
-    setTimeout(() => fetchData(), 5);
+    fetchData();
   }, [navYear, navMonth, addValue, editValue, deleteValue]);
 
   return (

--- a/src/components/common/ContainerBox.tsx
+++ b/src/components/common/ContainerBox.tsx
@@ -12,6 +12,7 @@ const StyledContainerBox = styled.div`
   background: ${(props) => props.theme.containerBoxColor};
   box-shadow: 0 0 25px rgba(0, 0, 0, 0.4);
   border-radius: 14px;
+  height: fit-content;
 `;
 
 export default ContainerBox;

--- a/src/components/modal/AddModal.tsx
+++ b/src/components/modal/AddModal.tsx
@@ -4,7 +4,7 @@ import "react-calendar/dist/Calendar.css";
 import "react-time-picker/dist/TimePicker.css";
 import { postConsume } from "../../lib/api/consumeAPI";
 import { FiPlus, FiMinus, FiX } from "react-icons/fi";
-import moment from "moment"
+import moment from "moment";
 
 interface IAddModalProps {
   handleCloseModal: () => void;
@@ -46,7 +46,7 @@ function AddModal({ handleCloseModal }: IAddModalProps) {
     setTimeValue(value);
   };
 
-  const handleConfirm = (event: any) => {
+  const handleConfirm = async (event: any) => {
     event.preventDefault();
     const date = moment(
       dateValue + (timeValue ? " " + timeValue : ""),
@@ -60,12 +60,13 @@ function AddModal({ handleCloseModal }: IAddModalProps) {
       return;
     }
 
-    postConsume({
+    await postConsume({
       amount,
       userId,
       category,
       date,
     });
+
     handleCloseModal();
   };
 

--- a/src/components/modal/DeleteModal.tsx
+++ b/src/components/modal/DeleteModal.tsx
@@ -10,14 +10,15 @@ interface IDeleteProps {
 }
 
 function DeleteModal({ id, handleCloseModal }: IDeleteProps) {
-  const handleConfirm = () => {
+  const handleConfirm = async () => {
     const deleteitem = {
       id: id,
     };
 
-    deleteConsume({
+    await deleteConsume({
       id: deleteitem.id,
     });
+
     handleCloseModal();
   };
 

--- a/src/components/modal/EditModal.tsx
+++ b/src/components/modal/EditModal.tsx
@@ -62,7 +62,9 @@ function EditModal({
     }
   };
 
-  const handleConfirm = () => {
+  const handleConfirm = async (event: any) => {
+    event.preventDefault();
+
     const editedConsume = {
       id: id,
       amount: editAmount,
@@ -83,13 +85,14 @@ function EditModal({
       return;
     }
 
-    putEditConsume({
+    await putEditConsume({
       id: editedConsume.id,
       amount: editedConsume.amount,
       userId: editedConsume.userId,
       category: editedConsume.category,
       date: editedConsume.date,
     });
+
     handleCloseModal();
   };
 

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -50,7 +50,7 @@ function Search({ userId }: ISearchProps) {
         console.log("Error occurred while searching:", error);
       }
     };
-    setTimeout(() => fetchData(), 5);
+    fetchData();
   }, [searchText, userId, addValue, openEditModal, openDeleteModal]);
 
   const handleCloseDeleteModal = () => {

--- a/src/components/today/Today.tsx
+++ b/src/components/today/Today.tsx
@@ -34,10 +34,6 @@ export function Today() {
   const nowDate = today.getDate();
   const [prevNowDate, setPrevNowDate] = useState<number | null>(null);
 
-  useEffect(() => {
-    console.log("컴온", todayList);
-  }, [todayList]);
-
   //api 호출
   useEffect(() => {
     const fetchData = async () => {
@@ -95,7 +91,7 @@ export function Today() {
         {nowMonth + 1}. {nowDate}
       </h1>
       <ListContainer>
-        {todayList === undefined ? (
+        {todayList.length === 0 ? (
           <div className="nodata">내역없음</div>
         ) : (
           todayList.map((a: IExpense) => (

--- a/src/components/today/Today.tsx
+++ b/src/components/today/Today.tsx
@@ -23,6 +23,7 @@ interface IExpense {
 export function Today() {
   const today = useRecoilValue(todayAtom);
   const addValue = useRecoilValue(openModalAtom);
+  const [todayListData, setTodayListData] = useState([]);
   const [todayList, setTodayList] = useState([]);
   const [openEditModal, setOpenEditModal] = useRecoilState(openEditModalAtom);
   const [openDeleteModal, setOpenDeleteModal] =
@@ -32,6 +33,7 @@ export function Today() {
   const nowYear = today.getFullYear();
   const nowDate = today.getDate();
 
+  //api 호출
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -40,22 +42,23 @@ export function Today() {
           month: nowMonth + 1,
           userId: "team1",
         });
-        const result = fetchRes.data;
-        setTodayList(result[Number(nowDate)]);
+        const result = await fetchRes.data;
+        setTodayListData(await result);
+        console.log("today 호출");
       } catch (error) {
         console.error(error);
       }
     };
-    setTimeout(() => fetchData(), 5);
-  }, [
-    openEditModal,
-    openDeleteModal,
-    addValue,
-    today,
-    nowDate,
-    nowMonth,
-    nowYear,
-  ]);
+    fetchData();
+    return () => {
+      fetchData();
+    };
+  }, [openEditModal, openDeleteModal, addValue, nowMonth, nowYear]);
+
+  //선택 일 변경시 호출된 데이터 안에서 date 조회
+  useEffect(() => {
+    setTodayList(todayListData[Number(nowDate)]);
+  }, [todayListData, nowDate]);
 
   const handleCloseDeleteModal = () => {
     setOpenDeleteModal(false);
@@ -89,9 +92,11 @@ export function Today() {
               <div>{a.category}</div>
               <IconBox>
                 {a.amount > 0 ? (
-                  <div className="posi mount">+{a.amount}원</div>
+                  <div className="posi mount">
+                    +{a.amount.toLocaleString()}원
+                  </div>
                 ) : (
-                  <div className="mount">{a.amount}원</div>
+                  <div className="mount">{a.amount.toLocaleString()}원</div>
                 )}
                 <EditButton onClick={() => handleOpenEditModal(a._id)}>
                   <RiPencilFill />

--- a/src/components/today/Today.tsx
+++ b/src/components/today/Today.tsx
@@ -42,8 +42,8 @@ export function Today() {
           month: nowMonth + 1,
           userId: "team1",
         });
-        const result = await fetchRes.data;
-        setTodayListData(await result);
+        const result = fetchRes.data;
+        setTodayListData(result);
         console.log("today 호출");
       } catch (error) {
         console.error(error);
@@ -87,7 +87,7 @@ export function Today() {
         {todayList === undefined ? (
           <div className="nodata">내역없음</div>
         ) : (
-          todayList.map((a: IExpense) => (
+          todayList.reverse().map((a: IExpense) => (
             <ListBox key={a._id}>
               <div>{a.category}</div>
               <IconBox>

--- a/src/components/today/Today.tsx
+++ b/src/components/today/Today.tsx
@@ -32,6 +32,11 @@ export function Today() {
   const nowMonth = today.getMonth();
   const nowYear = today.getFullYear();
   const nowDate = today.getDate();
+  const [prevNowDate, setPrevNowDate] = useState<number | null>(null);
+
+  useEffect(() => {
+    console.log("컴온", todayList);
+  }, [todayList]);
 
   //api 호출
   useEffect(() => {
@@ -44,20 +49,26 @@ export function Today() {
         });
         const result = fetchRes.data;
         setTodayListData(result);
-        console.log("today 호출");
       } catch (error) {
         console.error(error);
       }
     };
     fetchData();
-    return () => {
-      fetchData();
-    };
   }, [openEditModal, openDeleteModal, addValue, nowMonth, nowYear]);
 
-  //선택 일 변경시 호출된 데이터 안에서 date 조회
+  //선택 일 변경시 호출된 데이터 안에서 date 조회 후 reverse
   useEffect(() => {
-    setTodayList(todayListData[Number(nowDate)]);
+    const listData: [] =
+      todayListData[Number(nowDate)] !== undefined
+        ? todayListData[Number(nowDate)]
+        : [];
+    if (prevNowDate !== nowDate) {
+      setTodayList(listData);
+    }
+    setTodayList([...listData].reverse());
+    setPrevNowDate(nowDate);
+    return () => {};
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [todayListData, nowDate]);
 
   const handleCloseDeleteModal = () => {
@@ -87,7 +98,7 @@ export function Today() {
         {todayList === undefined ? (
           <div className="nodata">내역없음</div>
         ) : (
-          todayList.reverse().map((a: IExpense) => (
+          todayList.map((a: IExpense) => (
             <ListBox key={a._id}>
               <div>{a.category}</div>
               <IconBox>

--- a/src/lib/api/consumeAPI.ts
+++ b/src/lib/api/consumeAPI.ts
@@ -57,14 +57,14 @@ interface IPutEditConsume {
   date: string;
 }
 
-export const putEditConsume = ({
+export const putEditConsume = async ({
   id,
   amount,
   userId,
   category,
   date,
 }: IPutEditConsume) => {
-  client.put(`/api/expenses/${id}`, { amount, userId, category, date });
+  await client.put(`/api/expenses/${id}`, { amount, userId, category, date });
 };
 
 // 소비 기록 삭제 API(DELETE)

--- a/src/lib/api/consumeAPI.ts
+++ b/src/lib/api/consumeAPI.ts
@@ -13,13 +13,12 @@ export const postConsume = async ({
   category,
   date,
 }: IPostExpenses) => {
-  const result = await client.post("/api/expenses", {
+  await client.post("/api/expenses", {
     amount,
     userId,
     category,
     date,
   });
-  return result.data;
 };
 
 // 소비 품목 API(GET)
@@ -72,8 +71,7 @@ interface IDeleteConsume {
   id: string;
 }
 export const deleteConsume = async ({ id }: IDeleteConsume) => {
-  const result = await client.delete(`api/expenses/${id}`);
-  return result.data;
+  await client.delete(`api/expenses/${id}`);
 };
 
 // 소비 달력 호출 API(GET)


### PR DESCRIPTION
# 리팩토링
### Today.tsx의 api 재호출 방지 🔨 
Today.tsx 에서 CalendarView.tsx를 통해 선택한 날짜로 불러온 `getCalendarConsume` api는 해당 달에 등록되어있는 모든 기록들을 동일한 일로 묶어 반환합니다.
모달을 통한 변경사항이나 Month, Year의 변화 없이 단순히 Date만 이동하여 조회 할 시에 api를 재 호출하는게 아니라 이미 불러놓은 api 내에서 Date를 변경 후 재 조회 하게 하여 api 호출을 줄였습니다.
### consumeAPI.ts 내부의 불필요한 return 삭제 🔨 
`return` 값이 필요하지 않은 `post`, `delete`의 `return`을 삭제하였습니다.

# 추가된 기능
### Today.tsx의 list reverse ✨ 
Today.tsx의 리스트가 최신순 정렬이 되게 만들었습니다!

# 오류해결
### 모달을 통한 변경사항 자동반영 :bug:
해결 방법! ··· (멘토님 답변 정리)
1. consumeAPI.ts 내부의 client를 사용한 함수들은 모두 `promise` 값을 가집니다.
2. Modal 컴포넌트들의 `handleConfirm()` 함수는 api 호출 이후 `handleCloseModal()`를 처리합니다. 
하지만 호출 후 api가 처리되기 전에 `handleCloseModal()`를 실행하기 때문에 해당 문제가 발생하였습니다.
3. consumeAPI.ts에서 불러오는 api 호출 함수가 비동기 선언이 되어있다면, `handleConfirm()` 를 `async`를 통해 비동기처리한 후, `await`를 통해 api 함수의 비동기 작업 완료를 기다린 후 `handleCloseModal()`을 처리 할 수 있습니다.
> 따라서 비동기 선언이 되어있지 않았던 consumeAPI.ts 내부의 `putEditConsume`을 `async/await`통해 비동기로 만들어 주었습니다.
4. 그리고 editModal의 `handleConfirm()`는 submit event기 때문에, `event.preventDefault()` 설정으로 새로고침을 방지해주었습니다.

# 👍 

